### PR TITLE
New feature: return dummy data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-Endpoint for getting luas (dublin light rail), times and geo-coded data.
+Endpoint for getting Luas (Dublin light rail), times and geo-coded data.
 
-Updated to use a more simpler way of grabbing data from luas' endpoint.
+Updated to use a more simpler way of grabbing data from Luas' endpoint.
 
 This endpoint relies on http://www.luas.ie API endpoint and may break at any time, I will try my best to keep it updated.
 
 A working example can be seen [here](http://www.neilcremins.com/luas/v2/index.php?action=stations) and [here](http://www.neilcremins.com/luas/v2/index.php?action=times&station=STS)
 
-Example #1: Get times of next luas in both directions.
+Example #1: Get times of next Luas in both directions.
 
 index.php?action=**times**&station=**STS**
 
@@ -74,4 +74,47 @@ index.php?action=**stations**
 			}
 		},
 		...
+```
+
+
+Example #3: Get dummy times for trams in both directions. This is useful for testing purposes, particularly when services have stopped for the night. This data is always the same and is as below.
+
+index.php?action=**dummytimes**
+
+```javascript
+{
+    "message": "All services operating normally",
+    "trams": [
+        {
+            "destination": "Test Stop 1",
+            "direction": "Inbound",
+            "dueMinutes": "2"
+        },
+        {
+            "destination": "Test Stop 1",
+            "direction": "Inbound",
+            "dueMinutes": "8"
+        },
+        {
+            "destination": "Test Stop 1",
+            "direction": "Inbound",
+            "dueMinutes": "14"
+        },
+        {
+            "destination": "Test Stop 2",
+            "direction": "Outbound",
+            "dueMinutes": "4"
+        },
+        {
+            "destination": "Test Stop 2",
+            "direction": "Outbound",
+            "dueMinutes": "11"
+        },
+        {
+            "destination": "Test Stop 2",
+            "direction": "Outbound",
+            "dueMinutes": "18"
+        }
+    ]
+}
 ```

--- a/dummytimes.json
+++ b/dummytimes.json
@@ -1,0 +1,35 @@
+{
+    "message": "All services operating normally",
+    "trams": [
+        {
+            "destination": "Test Stop 1",
+            "direction": "Inbound",
+            "dueMinutes": "2"
+        },
+        {
+            "destination": "Test Stop 1",
+            "direction": "Inbound",
+            "dueMinutes": "8"
+        },
+        {
+            "destination": "Test Stop 1",
+            "direction": "Inbound",
+            "dueMinutes": "14"
+        },
+        {
+            "destination": "Test Stop 2",
+            "direction": "Outbound",
+            "dueMinutes": "4"
+        },
+        {
+            "destination": "Test Stop 2",
+            "direction": "Outbound",
+            "dueMinutes": "11"
+        },
+        {
+            "destination": "Test Stop 2",
+            "direction": "Outbound",
+            "dueMinutes": "18"
+        }
+    ]
+}

--- a/index.php
+++ b/index.php
@@ -93,7 +93,6 @@
 		, 'TPT'
 	);
 
-
 	/**
 	 * Return the contents of stations.json
 	 */
@@ -117,8 +116,6 @@
 		echo json_encode($error);
 		exit;
 	}
-
-
 
 	/**
 	 * $station should be a shortName from Stations.json
@@ -145,12 +142,11 @@
 			
 			$attribs = current($tram->attributes());
 
-			if ($attribs['dueMins'] > 0) {
+			if ($attribs['dueMins'] > 0 || $attribs['dueMins'] == "DUE") {
 				$timeEntry->dueMinutes = (string)$attribs['dueMins'];
 				$timeEntry->destination = (string)$attribs['destination'];
 				$time->trams[] = $timeEntry;
 			}
-			
 		}
 
 		foreach ($xml->direction[1]->tram as $key => $tram) {
@@ -159,7 +155,7 @@
 			
 			$attribs = current($tram->attributes());
 
-			if ($attribs['dueMins'] > 0) {
+			if ($attribs['dueMins'] > 0 || $attribs['dueMins'] == "DUE") {
 				$timeEntry->dueMinutes = (string)$attribs['dueMins'];
 				$timeEntry->destination = (string)$attribs['destination'];
 				$time->trams[] = $timeEntry;

--- a/index.php
+++ b/index.php
@@ -106,6 +106,11 @@
 		getStationTimes($station);
 		exit;
 	}
+    else if ($action == 'dummytimes') {
+       $json = file_get_contents('dummytimes.json');
+        echo $json;
+        exit; 
+    }
 	else {
 		$error = new stdClass();
 		$error->message = "Unknown station";


### PR DESCRIPTION
This is something I've needed for a while, so I've decided to add it as a feature to the API. Opening a request to the script with **?action=dummytimes** will return a JSON object with six fake trams. Very useful for testing when the trams have stopped running.

Updated the README with instructions on using this.